### PR TITLE
[feat] Visualize unrefed handles

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ Each nested `Node` has the following format:
                      // All timestamps are relative to the process startup time
                      // and the unit is nanoseconds.
 
+  unrefed: Boolean,  // `true` if the handle will not keep the event loop open.
+
   children: [        // Shows async operations created in the callback
     Node, ...
   ]

--- a/test/expected/console-log.json
+++ b/test/expected/console-log.json
@@ -2,53 +2,54 @@
  "stdout": "hallo world\n",
  "stderr": "",
  "dump": {
-  "total": 17721958,
+  "total": 19736161,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 16861533,
+   "destroy": 18606078,
    "before": [
     0
    ],
    "after": [
-    16828301
+    18573038
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,73 +59,74 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/console-log.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/console-log.js:2:1)",
      "filename": "/test/scripts/console-log.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "Pipe",
-     "init": 12106868,
+     "init": 12549028,
      "destroy": null,
      "before": [],
      "after": [],
+     "unrefed": true,
      "stack": [
       {
        "description": "createHandle (net.js:33:31)",
@@ -133,9 +135,9 @@
        "collum": 31
       },
       {
-       "description": "new Socket (net.js:138:20)",
+       "description": "new Socket (net.js:139:20)",
        "filename": "net.js",
-       "line": 138,
+       "line": 139,
        "collum": 20
       },
       {
@@ -157,81 +159,81 @@
        "collum": 37
       },
       {
-       "description": "NativeModule.compile (bootstrap_node.js:455:7)",
+       "description": "NativeModule.compile (bootstrap_node.js:497:7)",
        "filename": "bootstrap_node.js",
-       "line": 455,
+       "line": 497,
        "collum": 7
       },
       {
-       "description": "Function.NativeModule.require (bootstrap_node.js:396:18)",
+       "description": "Function.NativeModule.require (bootstrap_node.js:438:18)",
        "filename": "bootstrap_node.js",
-       "line": 396,
+       "line": 438,
        "collum": 18
       },
       {
-       "description": "Object.defineProperty.get (bootstrap_node.js:240:29)",
+       "description": "get (bootstrap_node.js:254:34)",
        "filename": "bootstrap_node.js",
-       "line": 240,
-       "collum": 29
+       "line": 254,
+       "collum": 34
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/console-log.js:4:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/console-log.js:4:1)",
        "filename": "/test/scripts/console-log.js",
        "line": 4,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
@@ -239,10 +241,11 @@
     },
     {
      "name": "Pipe",
-     "init": 13508583,
+     "init": 14445297,
      "destroy": null,
      "before": [],
      "after": [],
+     "unrefed": true,
      "stack": [
       {
        "description": "createHandle (net.js:33:31)",
@@ -251,9 +254,9 @@
        "collum": 31
       },
       {
-       "description": "new Socket (net.js:138:20)",
+       "description": "new Socket (net.js:139:20)",
        "filename": "net.js",
-       "line": 138,
+       "line": 139,
        "collum": 20
       },
       {
@@ -275,81 +278,81 @@
        "collum": 53
       },
       {
-       "description": "NativeModule.compile (bootstrap_node.js:455:7)",
+       "description": "NativeModule.compile (bootstrap_node.js:497:7)",
        "filename": "bootstrap_node.js",
-       "line": 455,
+       "line": 497,
        "collum": 7
       },
       {
-       "description": "Function.NativeModule.require (bootstrap_node.js:396:18)",
+       "description": "Function.NativeModule.require (bootstrap_node.js:438:18)",
        "filename": "bootstrap_node.js",
-       "line": 396,
+       "line": 438,
        "collum": 18
       },
       {
-       "description": "Object.defineProperty.get (bootstrap_node.js:240:29)",
+       "description": "get (bootstrap_node.js:254:34)",
        "filename": "bootstrap_node.js",
-       "line": 240,
-       "collum": 29
+       "line": 254,
+       "collum": 34
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/console-log.js:4:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/console-log.js:4:1)",
        "filename": "/test/scripts/console-log.js",
        "line": 4,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
@@ -357,14 +360,15 @@
     },
     {
      "name": "NextTickWrap",
-     "init": 15894965,
-     "destroy": 17356000,
+     "init": 17461032,
+     "destroy": 19317292,
      "before": [
-      17116499
+      18950413
      ],
      "after": [
-      17290064
+      19197667
      ],
+     "unrefed": false,
      "stack": [
       {
        "description": "onwrite (_stream_writable.js:350:15)",
@@ -379,15 +383,15 @@
        "collum": 5
       },
       {
-       "description": "Socket._writeGeneric (net.js:714:5)",
+       "description": "Socket._writeGeneric (net.js:715:5)",
        "filename": "net.js",
-       "line": 714,
+       "line": 715,
        "collum": 5
       },
       {
-       "description": "Socket._write (net.js:724:8)",
+       "description": "Socket._write (net.js:725:8)",
        "filename": "net.js",
-       "line": 724,
+       "line": 725,
        "collum": 8
       },
       {
@@ -409,9 +413,9 @@
        "collum": 11
       },
       {
-       "description": "Socket.write (net.js:650:40)",
+       "description": "Socket.write (net.js:651:40)",
        "filename": "net.js",
-       "line": 650,
+       "line": 651,
        "collum": 40
       },
       {
@@ -421,63 +425,63 @@
        "collum": 16
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/console-log.js:4:9)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/console-log.js:4:9)",
        "filename": "/test/scripts/console-log.js",
        "line": 4,
        "collum": 9
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],

--- a/test/expected/example.json
+++ b/test/expected/example.json
@@ -2,53 +2,54 @@
  "stdout": "",
  "stderr": "",
  "dump": {
-  "total": 7593346,
+  "total": 10431390,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 4346887,
+   "destroy": 5318423,
    "before": [
     0
    ],
    "after": [
-    4316288
+    5290321
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,150 +59,152 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/example.js:2:1)",
      "filename": "/test/scripts/example.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "TimeoutWrap",
-     "init": 3234326,
-     "destroy": 6324392,
+     "init": 3926668,
+     "destroy": 8156430,
      "before": [
-      4910358
+      5988105
      ],
      "after": [
-      6090412
+      7791902
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:6:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/example.js:6:1)",
        "filename": "/test/scripts/example.js",
        "line": 6,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
      "children": [
       {
        "name": "FSReqWrap",
-       "init": 5137186,
-       "destroy": 6927139,
+       "init": 6305194,
+       "destroy": 9255884,
        "before": [
-        6418801
+        8327808
        ],
        "after": [
-        6911356
+        9221510
        ],
+       "unrefed": false,
        "stack": [
         {
          "description": "Object.fs.open (fs.js:631:11)",
@@ -210,15 +213,15 @@
          "collum": 11
         },
         {
-         "description": "Timeout.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:8:6)",
+         "description": "Timeout.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/example.js:8:6)",
          "filename": "/test/scripts/example.js",
          "line": 8,
          "collum": 6
         },
         {
-         "description": "tryOnTimeout (timers.js:228:11)",
+         "description": "tryOnTimeout (timers.js:232:11)",
          "filename": "timers.js",
-         "line": 228,
+         "line": 232,
          "collum": 11
         },
         {
@@ -231,14 +234,15 @@
        "children": [
         {
          "name": "FSReqWrap",
-         "init": 6736433,
-         "destroy": 7184487,
+         "init": 8933201,
+         "destroy": 9768209,
          "before": [
-          7124834
+          9647955
          ],
          "after": [
-          7180561
+          9760116
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "Object.fs.read (fs.js:687:11)",
@@ -247,7 +251,7 @@
            "collum": 11
           },
           {
-           "description": "/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:13:8",
+           "description": "/Users/Jeremiah/Documents/dprof/test/scripts/example.js:13:8",
            "filename": "/test/scripts/example.js",
            "line": 13,
            "collum": 8
@@ -263,14 +267,15 @@
         },
         {
          "name": "FSReqWrap",
-         "init": 6858905,
-         "destroy": 7374832,
+         "init": 9135277,
+         "destroy": 10132330,
          "before": [
-          7188483
+          9777417
          ],
          "after": [
-          7370699
+          10125268
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "Object.fs.read (fs.js:687:11)",
@@ -279,7 +284,7 @@
            "collum": 11
           },
           {
-           "description": "/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:21:8",
+           "description": "/Users/Jeremiah/Documents/dprof/test/scripts/example.js:21:8",
            "filename": "/test/scripts/example.js",
            "line": 21,
            "collum": 8
@@ -294,14 +299,15 @@
          "children": [
           {
            "name": "FSReqWrap",
-           "init": 7307910,
-           "destroy": 7453932,
+           "init": 10016515,
+           "destroy": 10243990,
            "before": [
-            7414926
+            10186962
            ],
            "after": [
-            7449866
+            10237838
            ],
+           "unrefed": false,
            "stack": [
             {
              "description": "Object.fs.close (fs.js:605:11)",
@@ -310,13 +316,13 @@
              "collum": 11
             },
             {
-             "description": "close (/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:29:10)",
+             "description": "close (/Users/Jeremiah/Documents/dprof/test/scripts/example.js:29:10)",
              "filename": "/test/scripts/example.js",
              "line": 29,
              "collum": 10
             },
             {
-             "description": "/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:25:24",
+             "description": "/Users/Jeremiah/Documents/dprof/test/scripts/example.js:25:24",
              "filename": "/test/scripts/example.js",
              "line": 25,
              "collum": 24
@@ -336,14 +342,15 @@
       },
       {
        "name": "FSReqWrap",
-       "init": 5775829,
-       "destroy": 7027928,
+       "init": 7110395,
+       "destroy": 9456141,
        "before": [
-        6995428
+        9369336
        ],
        "after": [
-        7023671
+        9437967
        ],
+       "unrefed": false,
        "stack": [
         {
          "description": "Object.fs.readdir (fs.js:941:11)",
@@ -352,15 +359,15 @@
          "collum": 11
         },
         {
-         "description": "Timeout.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/example.js:35:6)",
+         "description": "Timeout.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/example.js:35:6)",
          "filename": "/test/scripts/example.js",
          "line": 35,
          "collum": 6
         },
         {
-         "description": "tryOnTimeout (timers.js:228:11)",
+         "description": "tryOnTimeout (timers.js:232:11)",
          "filename": "timers.js",
-         "line": 228,
+         "line": 232,
          "collum": 11
         },
         {

--- a/test/expected/http.json
+++ b/test/expected/http.json
@@ -2,53 +2,54 @@
  "stdout": "",
  "stderr": "",
  "dump": {
-  "total": 61569666,
+  "total": 70715974,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 19378501,
+   "destroy": 22246343,
    "before": [
     0
    ],
    "after": [
-    19289173
+    22206664
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,234 +59,238 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:3:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:3:1)",
      "filename": "/test/scripts/http.js",
      "line": 3,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "GetAddrInfoReqWrap",
-     "init": 18517849,
-     "destroy": 38949479,
+     "init": 21188653,
+     "destroy": 44721776,
      "before": [
-      20958695
+      23484045
      ],
      "after": [
-      28008213
+      32225091
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.lookup (dns.js:167:19)",
+       "description": "Object.lookup (dns.js:164:19)",
        "filename": "dns.js",
-       "line": 167,
+       "line": 164,
        "collum": 19
       },
       {
-       "description": "listenAfterLookup (net.js:1393:20)",
+       "description": "listenAfterLookup (net.js:1394:20)",
        "filename": "net.js",
-       "line": 1393,
+       "line": 1394,
        "collum": 20
       },
       {
-       "description": "Server.listen (net.js:1389:5)",
+       "description": "Server.listen (net.js:1390:5)",
        "filename": "net.js",
-       "line": 1389,
+       "line": 1390,
        "collum": 5
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:11:8)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:11:8)",
        "filename": "/test/scripts/http.js",
        "line": 11,
        "collum": 8
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
      "children": [
       {
        "name": "TCP",
-       "init": 26264851,
-       "destroy": 61010376,
+       "init": 30418335,
+       "destroy": 70177919,
        "before": [
-        39040817
+        44818873
        ],
        "after": [
-        42960185
+        47877507
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "createServerHandle (net.js:1179:14)",
+         "description": "createServerHandle (net.js:1180:14)",
          "filename": "net.js",
-         "line": 1179,
+         "line": 1180,
          "collum": 14
         },
         {
-         "description": "Server._listen2 (net.js:1236:14)",
+         "description": "Server._listen2 (net.js:1237:14)",
          "filename": "net.js",
-         "line": 1236,
+         "line": 1237,
          "collum": 14
         },
         {
-         "description": "listen (net.js:1288:10)",
+         "description": "listen (net.js:1289:10)",
          "filename": "net.js",
-         "line": 1288,
+         "line": 1289,
          "collum": 10
         },
         {
-         "description": "net.js:1398:9",
+         "description": "net.js:1399:9",
          "filename": "net.js",
-         "line": 1398,
+         "line": 1399,
          "collum": 9
         },
         {
-         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:65:16)",
+         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)",
          "filename": "dns.js",
-         "line": 65,
+         "line": 62,
          "collum": 16
         },
         {
-         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:84:10)",
+         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)",
          "filename": "dns.js",
-         "line": 84,
+         "line": 81,
          "collum": 10
         }
        ],
        "children": [
         {
          "name": "TCP",
-         "init": 39024922,
-         "destroy": 56224761,
+         "init": 44796972,
+         "destroy": 62737957,
          "before": [
-          56026138
+          62455640
          ],
          "after": [
-          56221075
+          62733021
          ],
+         "unrefed": false,
          "stack": [],
          "children": []
         },
         {
          "name": "HTTPParser",
-         "init": 41729219,
+         "init": 47281047,
          "destroy": null,
          "before": [
-          44937440,
-          52023280,
-          52862186
+          49202634,
+          57507991,
+          58572693
          ],
          "after": [
-          52008828,
-          52854040,
-          53042334
+          57497314,
+          58558421,
+          58816546
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "new <anonymous> (_http_common.js:159:16)",
@@ -318,23 +323,24 @@
            "collum": 7
           },
           {
-           "description": "TCP.onconnection (net.js:1458:8)",
+           "description": "TCP.onconnection (net.js:1459:8)",
            "filename": "net.js",
-           "line": 1458,
+           "line": 1459,
            "collum": 8
           }
          ],
          "children": [
           {
            "name": "NextTickWrap",
-           "init": 50050339,
-           "destroy": 53750171,
+           "init": 54758193,
+           "destroy": 59711898,
            "before": [
-            53048159
+            58823579
            ],
            "after": [
-            53745321
+            59701481
            ],
+           "unrefed": false,
            "stack": [
             {
              "description": "ServerResponse.OutgoingMessage._writeRaw (_http_outgoing.js:162:17)",
@@ -349,13 +355,13 @@
              "collum": 15
             },
             {
-             "description": "ServerResponse.OutgoingMessage.end (_http_outgoing.js:587:16)",
+             "description": "ServerResponse.OutgoingMessage.end (_http_outgoing.js:588:16)",
              "filename": "_http_outgoing.js",
-             "line": 587,
+             "line": 588,
              "collum": 16
             },
             {
-             "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:8:7)",
+             "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:8:7)",
              "filename": "/test/scripts/http.js",
              "line": 8,
              "collum": 7
@@ -388,25 +394,26 @@
            "children": [
             {
              "name": "NextTickWrap",
-             "init": 53269784,
-             "destroy": 55891258,
+             "init": 59099674,
+             "destroy": 62268356,
              "before": [
-              55556430
+              61882408
              ],
              "after": [
-              55889050
+              62265497
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "resume (_stream_readable.js:731:13)",
+               "description": "resume (_stream_readable.js:730:13)",
                "filename": "_stream_readable.js",
-               "line": 731,
+               "line": 730,
                "collum": 13
               },
               {
-               "description": "IncomingMessage.Readable.resume (_stream_readable.js:723:5)",
+               "description": "IncomingMessage.Readable.resume (_stream_readable.js:722:5)",
                "filename": "_stream_readable.js",
-               "line": 723,
+               "line": 722,
                "collum": 5
               },
               {
@@ -434,9 +441,9 @@
                "collum": 7
               },
               {
-               "description": "finish (_http_outgoing.js:580:10)",
+               "description": "finish (_http_outgoing.js:581:10)",
                "filename": "_http_outgoing.js",
-               "line": 580,
+               "line": 581,
                "collum": 10
               },
               {
@@ -455,31 +462,32 @@
              "children": [
               {
                "name": "NextTickWrap",
-               "init": 55658810,
-               "destroy": 55950972,
+               "init": 61970016,
+               "destroy": 62352844,
                "before": [
-                55947325
+                62342806
                ],
                "after": [
-                55949772
+                62346874
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:738:12)",
+                 "description": "resume_ (_stream_readable.js:737:12)",
                  "filename": "_stream_readable.js",
-                 "line": 738,
+                 "line": 737,
                  "collum": 12
                 },
                 {
@@ -499,37 +507,38 @@
               },
               {
                "name": "NextTickWrap",
-               "init": 55783739,
-               "destroy": 55954333,
+               "init": 62105124,
+               "destroy": 62359331,
                "before": [
-                55952298
+                62355492
                ],
                "after": [
-                55953369
+                62357727
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "flow (_stream_readable.js:762:34)",
+                 "description": "flow (_stream_readable.js:761:34)",
                  "filename": "_stream_readable.js",
-                 "line": 762,
+                 "line": 761,
                  "collum": 34
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:744:3)",
+                 "description": "resume_ (_stream_readable.js:743:3)",
                  "filename": "_stream_readable.js",
-                 "line": 744,
+                 "line": 743,
                  "collum": 3
                 },
                 {
@@ -549,31 +558,32 @@
               },
               {
                "name": "NextTickWrap",
-               "init": 55862075,
-               "destroy": 55959248,
+               "init": 62220404,
+               "destroy": 62364931,
                "before": [
-                55955499
+                62361699
                ],
                "after": [
-                55956453
+                62363461
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:746:12)",
+                 "description": "resume_ (_stream_readable.js:745:12)",
                  "filename": "_stream_readable.js",
-                 "line": 746,
+                 "line": 745,
                  "collum": 12
                 },
                 {
@@ -597,14 +607,15 @@
           },
           {
            "name": "NextTickWrap",
-           "init": 50873828,
-           "destroy": 55294346,
+           "init": 55760146,
+           "destroy": 61544290,
            "before": [
-            53759361
+            59730050
            ],
            "after": [
-            55287071
+            61540170
            ],
+           "unrefed": false,
            "stack": [
             {
              "description": "onwrite (_stream_writable.js:350:15)",
@@ -619,15 +630,15 @@
              "collum": 5
             },
             {
-             "description": "Socket._writeGeneric (net.js:714:5)",
+             "description": "Socket._writeGeneric (net.js:715:5)",
              "filename": "net.js",
-             "line": 714,
+             "line": 715,
              "collum": 5
             },
             {
-             "description": "Socket._write (net.js:724:8)",
+             "description": "Socket._write (net.js:725:8)",
              "filename": "net.js",
-             "line": 724,
+             "line": 725,
              "collum": 8
             },
             {
@@ -649,13 +660,13 @@
              "collum": 7
             },
             {
-             "description": "ServerResponse.OutgoingMessage.end (_http_outgoing.js:591:21)",
+             "description": "ServerResponse.OutgoingMessage.end (_http_outgoing.js:592:21)",
              "filename": "_http_outgoing.js",
-             "line": 591,
+             "line": 592,
              "collum": 21
             },
             {
-             "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:8:7)",
+             "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:8:7)",
              "filename": "/test/scripts/http.js",
              "line": 8,
              "collum": 7
@@ -688,19 +699,20 @@
            "children": [
             {
              "name": "ShutdownWrap",
-             "init": 54030037,
-             "destroy": 56023077,
+             "init": 60050877,
+             "destroy": 62450462,
              "before": [
-              55969638
+              62376271
              ],
              "after": [
-              56019933
+              62445776
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "Socket.onSocketFinish (net.js:225:26)",
+               "description": "Socket.onSocketFinish (net.js:226:26)",
                "filename": "net.js",
-               "line": 225,
+               "line": 226,
                "collum": 26
               },
               {
@@ -744,10 +756,11 @@
             },
             {
              "name": "Pipe",
-             "init": 54825176,
+             "init": 60913595,
              "destroy": null,
              "before": [],
              "after": [],
+             "unrefed": true,
              "stack": [
               {
                "description": "createHandle (net.js:33:31)",
@@ -756,9 +769,9 @@
                "collum": 31
               },
               {
-               "description": "new Socket (net.js:138:20)",
+               "description": "new Socket (net.js:139:20)",
                "filename": "net.js",
-               "line": 138,
+               "line": 139,
                "collum": 20
               },
               {
@@ -774,15 +787,15 @@
                "collum": 14
               },
               {
-               "description": "Socket._destroy (net.js:484:25)",
+               "description": "Socket._destroy (net.js:485:25)",
                "filename": "net.js",
-               "line": 484,
+               "line": 485,
                "collum": 25
               },
               {
-               "description": "Socket.destroy (net.js:518:8)",
+               "description": "Socket.destroy (net.js:519:8)",
                "filename": "net.js",
-               "line": 518,
+               "line": 519,
                "collum": 8
               },
               {
@@ -834,37 +847,38 @@
           },
           {
            "name": "NextTickWrap",
-           "init": 52649300,
-           "destroy": 55550851,
+           "init": 58312007,
+           "destroy": 61878372,
            "before": [
-            55298910
+            61549372
            ],
            "after": [
-            55548379
+            61875483
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "emitReadable (_stream_readable.js:425:15)",
+             "description": "emitReadable (_stream_readable.js:424:15)",
              "filename": "_stream_readable.js",
-             "line": 425,
+             "line": 424,
              "collum": 15
             },
             {
-             "description": "onEofChunk (_stream_readable.js:412:3)",
+             "description": "onEofChunk (_stream_readable.js:411:3)",
              "filename": "_stream_readable.js",
-             "line": 412,
+             "line": 411,
              "collum": 3
             },
             {
-             "description": "readableAddChunk (_stream_readable.js:154:5)",
+             "description": "readableAddChunk (_stream_readable.js:153:5)",
              "filename": "_stream_readable.js",
-             "line": 154,
+             "line": 153,
              "collum": 5
             },
             {
-             "description": "IncomingMessage.Readable.push (_stream_readable.js:135:10)",
+             "description": "IncomingMessage.Readable.push (_stream_readable.js:134:10)",
              "filename": "_stream_readable.js",
-             "line": 135,
+             "line": 134,
              "collum": 10
             },
             {
@@ -877,25 +891,26 @@
            "children": [
             {
              "name": "NextTickWrap",
-             "init": 55492947,
-             "destroy": 55944819,
+             "init": 61803258,
+             "destroy": 62339098,
              "before": [
-              55893888
+              62271988
              ],
              "after": [
-              55939566
+              62336022
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "endReadable (_stream_readable.js:966:13)",
+               "description": "endReadable (_stream_readable.js:965:13)",
                "filename": "_stream_readable.js",
-               "line": 966,
+               "line": 965,
                "collum": 13
               },
               {
-               "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+               "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                "filename": "_stream_readable.js",
-               "line": 300,
+               "line": 299,
                "collum": 7
               },
               {
@@ -905,15 +920,15 @@
                "collum": 15
               },
               {
-               "description": "flow (_stream_readable.js:762:34)",
+               "description": "flow (_stream_readable.js:761:34)",
                "filename": "_stream_readable.js",
-               "line": 762,
+               "line": 761,
                "collum": 34
               },
               {
-               "description": "emitReadable_ (_stream_readable.js:434:3)",
+               "description": "emitReadable_ (_stream_readable.js:433:3)",
                "filename": "_stream_readable.js",
-               "line": 434,
+               "line": 433,
                "collum": 3
               },
               {
@@ -937,31 +952,32 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 42572969,
-         "destroy": 43375927,
+         "init": 47736951,
+         "destroy": 48180809,
          "before": [
-          42972794
+          47943343
          ],
          "after": [
-          43368856
+          48176831
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "resume (_stream_readable.js:731:13)",
+           "description": "resume (_stream_readable.js:730:13)",
            "filename": "_stream_readable.js",
-           "line": 731,
+           "line": 730,
            "collum": 13
           },
           {
-           "description": "Socket.Readable.resume (_stream_readable.js:723:5)",
+           "description": "Socket.Readable.resume (_stream_readable.js:722:5)",
            "filename": "_stream_readable.js",
-           "line": 723,
+           "line": 722,
            "collum": 5
           },
           {
-           "description": "Socket.Readable.on (_stream_readable.js:693:12)",
+           "description": "Socket.Readable.on (_stream_readable.js:692:12)",
            "filename": "_stream_readable.js",
-           "line": 693,
+           "line": 692,
            "collum": 12
           },
           {
@@ -983,9 +999,9 @@
            "collum": 7
           },
           {
-           "description": "TCP.onconnection (net.js:1458:8)",
+           "description": "TCP.onconnection (net.js:1459:8)",
            "filename": "net.js",
-           "line": 1458,
+           "line": 1459,
            "collum": 8
           }
          ],
@@ -995,70 +1011,72 @@
       },
       {
        "name": "NextTickWrap",
-       "init": 27654767,
-       "destroy": 36103093,
+       "init": 31900287,
+       "destroy": 41180483,
        "before": [
-        28120391
+        32372330
        ],
        "after": [
-        36029459
+        41064108
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "Server._listen2 (net.js:1266:11)",
+         "description": "Server._listen2 (net.js:1267:11)",
          "filename": "net.js",
-         "line": 1266,
+         "line": 1267,
          "collum": 11
         },
         {
-         "description": "listen (net.js:1288:10)",
+         "description": "listen (net.js:1289:10)",
          "filename": "net.js",
-         "line": 1288,
+         "line": 1289,
          "collum": 10
         },
         {
-         "description": "net.js:1398:9",
+         "description": "net.js:1399:9",
          "filename": "net.js",
-         "line": 1398,
+         "line": 1399,
          "collum": 9
         },
         {
-         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:65:16)",
+         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)",
          "filename": "dns.js",
-         "line": 65,
+         "line": 62,
          "collum": 16
         },
         {
-         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:84:10)",
+         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)",
          "filename": "dns.js",
-         "line": 84,
+         "line": 81,
          "collum": 10
         }
        ],
        "children": [
         {
          "name": "TCP",
-         "init": 33314177,
-         "destroy": 61467859,
+         "init": 37922940,
+         "destroy": 70609973,
          "before": [
-          56255571,
-          61031679
+          62773015,
+          70239947
          ],
          "after": [
-          57919607,
-          61460267
+          65007072,
+          70602432
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "Socket.connect (net.js:913:40)",
+           "description": "Socket.connect (net.js:914:40)",
            "filename": "net.js",
-           "line": 913,
+           "line": 914,
            "collum": 40
           },
           {
-           "description": "Agent.exports.connect.exports.createConnection (net.js:70:35)",
+           "description": "Agent.exports.connect.exports.createConnection (net.js:69:35)",
            "filename": "net.js",
-           "line": 70,
+           "line": 69,
            "collum": 35
           },
           {
@@ -1092,7 +1110,7 @@
            "collum": 21
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:13:8)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:13:8)",
            "filename": "/test/scripts/http.js",
            "line": 13,
            "collum": 8
@@ -1116,9 +1134,9 @@
            "collum": 7
           },
           {
-           "description": "emitListeningNT (net.js:1278:10)",
+           "description": "emitListeningNT (net.js:1279:10)",
            "filename": "net.js",
-           "line": 1278,
+           "line": 1279,
            "collum": 10
           },
           {
@@ -1138,31 +1156,32 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 34205198,
-         "destroy": 36624766,
+         "init": 38949281,
+         "destroy": 41765188,
          "before": [
-          36251887
+          41351972
          ],
          "after": [
-          36612655
+          41751115
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "lookupAndConnect (net.js:961:13)",
+           "description": "lookupAndConnect (net.js:962:13)",
            "filename": "net.js",
-           "line": 961,
+           "line": 962,
            "collum": 13
           },
           {
-           "description": "Socket.connect (net.js:929:5)",
+           "description": "Socket.connect (net.js:930:5)",
            "filename": "net.js",
-           "line": 929,
+           "line": 930,
            "collum": 5
           },
           {
-           "description": "Agent.exports.connect.exports.createConnection (net.js:70:35)",
+           "description": "Agent.exports.connect.exports.createConnection (net.js:69:35)",
            "filename": "net.js",
-           "line": 70,
+           "line": 69,
            "collum": 35
           },
           {
@@ -1196,7 +1215,7 @@
            "collum": 21
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:13:8)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:13:8)",
            "filename": "/test/scripts/http.js",
            "line": 13,
            "collum": 8
@@ -1220,9 +1239,9 @@
            "collum": 7
           },
           {
-           "description": "emitListeningNT (net.js:1278:10)",
+           "description": "emitListeningNT (net.js:1279:10)",
            "filename": "net.js",
-           "line": 1278,
+           "line": 1279,
            "collum": 10
           },
           {
@@ -1241,25 +1260,26 @@
          "children": [
           {
            "name": "TCPConnectWrap",
-           "init": 36480495,
-           "destroy": 44789436,
+           "init": 41616993,
+           "destroy": 49107143,
            "before": [
-            43405487
+            48200866
            ],
            "after": [
-            44778909
+            49101514
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "connect (net.js:854:26)",
+             "description": "connect (net.js:856:26)",
              "filename": "net.js",
-             "line": 854,
+             "line": 856,
              "collum": 26
             },
             {
-             "description": "net.js:963:9",
+             "description": "net.js:964:9",
              "filename": "net.js",
-             "line": 963,
+             "line": 964,
              "collum": 9
             },
             {
@@ -1281,14 +1301,15 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 35034297,
-         "destroy": 38393805,
+         "init": 39739533,
+         "destroy": 44052122,
          "before": [
-          36639382
+          41777181
          ],
          "after": [
-          38389815
+          44048506
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "ClientRequest.onSocket (_http_client.js:566:11)",
@@ -1339,7 +1360,7 @@
            "collum": 21
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:13:8)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:13:8)",
            "filename": "/test/scripts/http.js",
            "line": 13,
            "collum": 8
@@ -1363,9 +1384,9 @@
            "collum": 7
           },
           {
-           "description": "emitListeningNT (net.js:1278:10)",
+           "description": "emitListeningNT (net.js:1279:10)",
            "filename": "net.js",
-           "line": 1278,
+           "line": 1279,
            "collum": 10
           },
           {
@@ -1384,18 +1405,19 @@
          "children": [
           {
            "name": "HTTPParser",
-           "init": 36891413,
+           "init": 42093147,
            "destroy": null,
            "before": [
-            56509851,
-            57296676,
-            57469731
+            63124967,
+            64192910,
+            64415704
            ],
            "after": [
-            57291690,
-            57465575,
-            57676873
+            64187066,
+            64410363,
+            64670989
            ],
+           "unrefed": false,
            "stack": [
             {
              "description": "new <anonymous> (_http_common.js:159:16)",
@@ -1437,29 +1459,30 @@
            "children": [
             {
              "name": "NextTickWrap",
-             "init": 57077839,
-             "destroy": 58275636,
+             "init": 63894771,
+             "destroy": 67127993,
              "before": [
-              57923196
+              65015334
              ],
              "after": [
-              58273394
+              67125097
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "resume (_stream_readable.js:731:13)",
+               "description": "resume (_stream_readable.js:730:13)",
                "filename": "_stream_readable.js",
-               "line": 731,
+               "line": 730,
                "collum": 13
               },
               {
-               "description": "IncomingMessage.Readable.resume (_stream_readable.js:723:5)",
+               "description": "IncomingMessage.Readable.resume (_stream_readable.js:722:5)",
                "filename": "_stream_readable.js",
-               "line": 723,
+               "line": 722,
                "collum": 5
               },
               {
-               "description": "ClientRequest.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/http.js:14:9)",
+               "description": "ClientRequest.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/http.js:14:9)",
                "filename": "/test/scripts/http.js",
                "line": 14,
                "collum": 9
@@ -1513,58 +1536,59 @@
                "collum": 7
               },
               {
-               "description": "readableAddChunk (_stream_readable.js:177:18)",
+               "description": "readableAddChunk (_stream_readable.js:176:18)",
                "filename": "_stream_readable.js",
-               "line": 177,
+               "line": 176,
                "collum": 18
               },
               {
-               "description": "Socket.Readable.push (_stream_readable.js:135:10)",
+               "description": "Socket.Readable.push (_stream_readable.js:134:10)",
                "filename": "_stream_readable.js",
-               "line": 135,
+               "line": 134,
                "collum": 10
               },
               {
-               "description": "TCP.onread (net.js:542:20)",
+               "description": "TCP.onread (net.js:543:20)",
                "filename": "net.js",
-               "line": 542,
+               "line": 543,
                "collum": 20
               }
              ],
              "children": [
               {
                "name": "NextTickWrap",
-               "init": 58096378,
-               "destroy": 60705157,
+               "init": 65264712,
+               "destroy": 70075847,
                "before": [
-                59464099
+                68977529
                ],
                "after": [
-                60701616
+                70000571
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:378:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:377:7)",
                  "filename": "_stream_readable.js",
-                 "line": 378,
+                 "line": 377,
                  "collum": 7
                 },
                 {
-                 "description": "flow (_stream_readable.js:762:34)",
+                 "description": "flow (_stream_readable.js:761:34)",
                  "filename": "_stream_readable.js",
-                 "line": 762,
+                 "line": 761,
                  "collum": 34
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:744:3)",
+                 "description": "resume_ (_stream_readable.js:743:3)",
                  "filename": "_stream_readable.js",
-                 "line": 744,
+                 "line": 743,
                  "collum": 3
                 },
                 {
@@ -1583,19 +1607,20 @@
                "children": [
                 {
                  "name": "ShutdownWrap",
-                 "init": 59846512,
-                 "destroy": 61026740,
+                 "init": 69426055,
+                 "destroy": 70235315,
                  "before": [
-                  61017390
+                  70195429
                  ],
                  "after": [
-                  61024713
+                  70231595
                  ],
+                 "unrefed": false,
                  "stack": [
                   {
-                   "description": "Socket.onSocketFinish (net.js:225:26)",
+                   "description": "Socket.onSocketFinish (net.js:226:26)",
                    "filename": "net.js",
-                   "line": 225,
+                   "line": 226,
                    "collum": 26
                   },
                   {
@@ -1629,15 +1654,15 @@
                    "collum": 5
                   },
                   {
-                   "description": "Socket.end (net.js:422:31)",
+                   "description": "Socket.end (net.js:423:31)",
                    "filename": "net.js",
-                   "line": 422,
+                   "line": 423,
                    "collum": 31
                   },
                   {
-                   "description": "Socket.destroySoon (net.js:449:10)",
+                   "description": "Socket.destroySoon (net.js:450:10)",
                    "filename": "net.js",
-                   "line": 449,
+                   "line": 450,
                    "collum": 10
                   },
                   {
@@ -1665,9 +1690,9 @@
                    "collum": 7
                   },
                   {
-                   "description": "endReadableNT (_stream_readable.js:975:12)",
+                   "description": "endReadableNT (_stream_readable.js:974:12)",
                    "filename": "_stream_readable.js",
-                   "line": 975,
+                   "line": 974,
                    "collum": 12
                   },
                   {
@@ -1687,25 +1712,26 @@
                 },
                 {
                  "name": "NextTickWrap",
-                 "init": 60587874,
-                 "destroy": 61001736,
+                 "init": 69923843,
+                 "destroy": 70169090,
                  "before": [
-                  60950627
+                  70099648
                  ],
                  "after": [
-                  60999083
+                  70166388
                  ],
+                 "unrefed": false,
                  "stack": [
                   {
-                   "description": "Server._emitCloseIfDrained (net.js:1542:11)",
+                   "description": "Server._emitCloseIfDrained (net.js:1543:11)",
                    "filename": "net.js",
-                   "line": 1542,
+                   "line": 1543,
                    "collum": 11
                   },
                   {
-                   "description": "Server.close (net.js:1527:10)",
+                   "description": "Server.close (net.js:1528:10)",
                    "filename": "net.js",
-                   "line": 1527,
+                   "line": 1528,
                    "collum": 10
                   },
                   {
@@ -1727,9 +1753,9 @@
                    "collum": 7
                   },
                   {
-                   "description": "endReadableNT (_stream_readable.js:975:12)",
+                   "description": "endReadableNT (_stream_readable.js:974:12)",
                    "filename": "_stream_readable.js",
-                   "line": 975,
+                   "line": 974,
                    "collum": 12
                   },
                   {
@@ -1751,37 +1777,38 @@
               },
               {
                "name": "NextTickWrap",
-               "init": 58173760,
-               "destroy": 60927527,
+               "init": 65388778,
+               "destroy": 70085826,
                "before": [
-                60709112
+                70081407
                ],
                "after": [
-                60922817
+                70084200
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "flow (_stream_readable.js:762:34)",
+                 "description": "flow (_stream_readable.js:761:34)",
                  "filename": "_stream_readable.js",
-                 "line": 762,
+                 "line": 761,
                  "collum": 34
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:744:3)",
+                 "description": "resume_ (_stream_readable.js:743:3)",
                  "filename": "_stream_readable.js",
-                 "line": 744,
+                 "line": 743,
                  "collum": 3
                 },
                 {
@@ -1801,31 +1828,32 @@
               },
               {
                "name": "NextTickWrap",
-               "init": 58241216,
-               "destroy": 60944083,
+               "init": 67064701,
+               "destroy": 70091481,
                "before": [
-                60939936
+                70088276
                ],
                "after": [
-                60942546
+                70090071
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "resume_ (_stream_readable.js:746:12)",
+                 "description": "resume_ (_stream_readable.js:745:12)",
                  "filename": "_stream_readable.js",
-                 "line": 746,
+                 "line": 745,
                  "collum": 12
                 },
                 {
@@ -1847,37 +1875,38 @@
             },
             {
              "name": "NextTickWrap",
-             "init": 57574511,
-             "destroy": 59362098,
+             "init": 64545682,
+             "destroy": 68895852,
              "before": [
-              58278808
+              67132593
              ],
              "after": [
-              59358792
+              68892607
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "emitReadable (_stream_readable.js:425:15)",
+               "description": "emitReadable (_stream_readable.js:424:15)",
                "filename": "_stream_readable.js",
-               "line": 425,
+               "line": 424,
                "collum": 15
               },
               {
-               "description": "onEofChunk (_stream_readable.js:412:3)",
+               "description": "onEofChunk (_stream_readable.js:411:3)",
                "filename": "_stream_readable.js",
-               "line": 412,
+               "line": 411,
                "collum": 3
               },
               {
-               "description": "readableAddChunk (_stream_readable.js:154:5)",
+               "description": "readableAddChunk (_stream_readable.js:153:5)",
                "filename": "_stream_readable.js",
-               "line": 154,
+               "line": 153,
                "collum": 5
               },
               {
-               "description": "IncomingMessage.Readable.push (_stream_readable.js:135:10)",
+               "description": "IncomingMessage.Readable.push (_stream_readable.js:134:10)",
                "filename": "_stream_readable.js",
-               "line": 135,
+               "line": 134,
                "collum": 10
               },
               {
@@ -1905,58 +1934,59 @@
                "collum": 7
               },
               {
-               "description": "readableAddChunk (_stream_readable.js:177:18)",
+               "description": "readableAddChunk (_stream_readable.js:176:18)",
                "filename": "_stream_readable.js",
-               "line": 177,
+               "line": 176,
                "collum": 18
               },
               {
-               "description": "Socket.Readable.push (_stream_readable.js:135:10)",
+               "description": "Socket.Readable.push (_stream_readable.js:134:10)",
                "filename": "_stream_readable.js",
-               "line": 135,
+               "line": 134,
                "collum": 10
               },
               {
-               "description": "TCP.onread (net.js:542:20)",
+               "description": "TCP.onread (net.js:543:20)",
                "filename": "net.js",
-               "line": 542,
+               "line": 543,
                "collum": 20
               }
              ],
              "children": [
               {
                "name": "NextTickWrap",
-               "init": 59266490,
-               "destroy": 60948817,
+               "init": 68523599,
+               "destroy": 70097411,
                "before": [
-                60946043
+                70093949
                ],
                "after": [
-                60947545
+                70095796
                ],
+               "unrefed": false,
                "stack": [
                 {
-                 "description": "endReadable (_stream_readable.js:966:13)",
+                 "description": "endReadable (_stream_readable.js:965:13)",
                  "filename": "_stream_readable.js",
-                 "line": 966,
+                 "line": 965,
                  "collum": 13
                 },
                 {
-                 "description": "IncomingMessage.Readable.read (_stream_readable.js:300:7)",
+                 "description": "IncomingMessage.Readable.read (_stream_readable.js:299:7)",
                  "filename": "_stream_readable.js",
-                 "line": 300,
+                 "line": 299,
                  "collum": 7
                 },
                 {
-                 "description": "flow (_stream_readable.js:762:34)",
+                 "description": "flow (_stream_readable.js:761:34)",
                  "filename": "_stream_readable.js",
-                 "line": 762,
+                 "line": 761,
                  "collum": 34
                 },
                 {
-                 "description": "emitReadable_ (_stream_readable.js:434:3)",
+                 "description": "emitReadable_ (_stream_readable.js:433:3)",
                  "filename": "_stream_readable.js",
-                 "line": 434,
+                 "line": 433,
                  "collum": 3
                 },
                 {
@@ -1980,31 +2010,32 @@
           },
           {
            "name": "NextTickWrap",
-           "init": 37171172,
-           "destroy": 38937286,
+           "init": 42487781,
+           "destroy": 44711478,
            "before": [
-            38398034
+            44056895
            ],
            "after": [
-            38933403
+            44708135
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "resume (_stream_readable.js:731:13)",
+             "description": "resume (_stream_readable.js:730:13)",
              "filename": "_stream_readable.js",
-             "line": 731,
+             "line": 730,
              "collum": 13
             },
             {
-             "description": "Socket.Readable.resume (_stream_readable.js:723:5)",
+             "description": "Socket.Readable.resume (_stream_readable.js:722:5)",
              "filename": "_stream_readable.js",
-             "line": 723,
+             "line": 722,
              "collum": 5
             },
             {
-             "description": "Socket.Readable.on (_stream_readable.js:693:12)",
+             "description": "Socket.Readable.on (_stream_readable.js:692:12)",
              "filename": "_stream_readable.js",
-             "line": 693,
+             "line": 692,
              "collum": 12
             },
             {
@@ -2042,37 +2073,38 @@
     },
     {
      "name": "NextTickWrap",
-     "init": 57879136,
-     "destroy": 59457818,
+     "init": 64953325,
+     "destroy": 68974329,
      "before": [
-      59366080
+      68899923
      ],
      "after": [
-      59453817
+      68971437
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "maybeReadMore (_stream_readable.js:447:13)",
+       "description": "maybeReadMore (_stream_readable.js:446:13)",
        "filename": "_stream_readable.js",
-       "line": 447,
+       "line": 446,
        "collum": 13
       },
       {
-       "description": "readableAddChunk (_stream_readable.js:192:7)",
+       "description": "readableAddChunk (_stream_readable.js:191:7)",
        "filename": "_stream_readable.js",
-       "line": 192,
+       "line": 191,
        "collum": 7
       },
       {
-       "description": "Socket.Readable.push (_stream_readable.js:135:10)",
+       "description": "Socket.Readable.push (_stream_readable.js:134:10)",
        "filename": "_stream_readable.js",
-       "line": 135,
+       "line": 134,
        "collum": 10
       },
       {
-       "description": "TCP.onread (net.js:542:20)",
+       "description": "TCP.onread (net.js:543:20)",
        "filename": "net.js",
-       "line": 542,
+       "line": 543,
        "collum": 20
       }
      ],

--- a/test/expected/set-timeout-clear.json
+++ b/test/expected/set-timeout-clear.json
@@ -2,53 +2,54 @@
  "stdout": "",
  "stderr": "",
  "dump": {
-  "total": 106408878,
+  "total": 110405763,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 5541408,
+   "destroy": 6215090,
    "before": [
     0
    ],
    "after": [
-    5509761
+    6183755
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,132 +59,133 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout-clear.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout-clear.js:2:1)",
      "filename": "/test/scripts/set-timeout-clear.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "TimeoutWrap",
-     "init": 3605127,
-     "destroy": 18373855,
+     "init": 3901505,
+     "destroy": 19514666,
      "before": [],
      "after": [],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout-clear.js:4:15)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout-clear.js:4:15)",
        "filename": "/test/scripts/set-timeout-clear.js",
        "line": 4,
        "collum": 15
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
@@ -191,73 +193,74 @@
     },
     {
      "name": "TimeoutWrap",
-     "init": 4807971,
-     "destroy": 18948924,
+     "init": 5236431,
+     "destroy": 20178907,
      "before": [
-      17835801
+      18927096
      ],
      "after": [
-      18909695
+      20132710
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout-clear.js:6:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout-clear.js:6:1)",
        "filename": "/test/scripts/set-timeout-clear.js",
        "line": 6,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
@@ -265,73 +268,74 @@
     },
     {
      "name": "TimeoutWrap",
-     "init": 5196815,
-     "destroy": 106090301,
+     "init": 5839110,
+     "destroy": 109922211,
      "before": [
-      105986156
+      109737311
      ],
      "after": [
-      106074000
+      109884288
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout-clear.js:10:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout-clear.js:10:1)",
        "filename": "/test/scripts/set-timeout-clear.js",
        "line": 10,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],

--- a/test/expected/set-timeout.json
+++ b/test/expected/set-timeout.json
@@ -2,53 +2,54 @@
  "stdout": "",
  "stderr": "",
  "dump": {
-  "total": 27966898,
+  "total": 31973568,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 4603226,
+   "destroy": 5332093,
    "before": [
     0
    ],
    "after": [
-    4572081
+    5302022
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,161 +59,163 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout.js:2:1)",
      "filename": "/test/scripts/set-timeout.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "TimeoutWrap",
-     "init": 3164538,
-     "destroy": 16663804,
+     "init": 3923997,
+     "destroy": 20304362,
      "before": [
-      14824758
+      18181211
      ],
      "after": [
-      16338533
+      19940944
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout.js:4:1)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout.js:4:1)",
        "filename": "/test/scripts/set-timeout.js",
        "line": 4,
        "collum": 1
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
      "children": [
       {
        "name": "TimeoutWrap",
-       "init": 15113933,
-       "destroy": 27305424,
+       "init": 18905744,
+       "destroy": 31246204,
        "before": [
-        27200889
+        30970224
        ],
        "after": [
-        27277780
+        31173346
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "Timeout.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout.js:5:3)",
+         "description": "Timeout.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout.js:5:3)",
          "filename": "/test/scripts/set-timeout.js",
          "line": 5,
          "collum": 3
         },
         {
-         "description": "tryOnTimeout (timers.js:228:11)",
+         "description": "tryOnTimeout (timers.js:232:11)",
          "filename": "timers.js",
-         "line": 228,
+         "line": 232,
          "collum": 11
         },
         {
@@ -226,25 +229,26 @@
       },
       {
        "name": "TimeoutWrap",
-       "init": 15963249,
-       "destroy": 27355113,
+       "init": 19626490,
+       "destroy": 31370250,
        "before": [
-        27318605
+        31262848
        ],
        "after": [
-        27347931
+        31343388
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "Timeout.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/set-timeout.js:7:3)",
+         "description": "Timeout.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/set-timeout.js:7:3)",
          "filename": "/test/scripts/set-timeout.js",
          "line": 7,
          "collum": 3
         },
         {
-         "description": "tryOnTimeout (timers.js:228:11)",
+         "description": "tryOnTimeout (timers.js:232:11)",
          "filename": "timers.js",
-         "line": 228,
+         "line": 232,
          "collum": 11
         },
         {

--- a/test/expected/tcp.json
+++ b/test/expected/tcp.json
@@ -2,53 +2,54 @@
  "stdout": "",
  "stderr": "",
  "dump": {
-  "total": 32053239,
+  "total": 40693153,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 11926529,
+   "destroy": 16339578,
    "before": [
     0
    ],
    "after": [
-    11872868
+    16295330
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,260 +59,264 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:2:1)",
      "filename": "/test/scripts/tcp.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "GetAddrInfoReqWrap",
-     "init": 11141187,
-     "destroy": 23410302,
+     "init": 15323023,
+     "destroy": 29702905,
      "before": [
-      13395768
+      17723978
      ],
      "after": [
-      20119402
+      25831553
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "Object.lookup (dns.js:167:19)",
+       "description": "Object.lookup (dns.js:164:19)",
        "filename": "dns.js",
-       "line": 167,
+       "line": 164,
        "collum": 19
       },
       {
-       "description": "listenAfterLookup (net.js:1393:20)",
+       "description": "listenAfterLookup (net.js:1394:20)",
        "filename": "net.js",
-       "line": 1393,
+       "line": 1394,
        "collum": 20
       },
       {
-       "description": "Server.listen (net.js:1389:5)",
+       "description": "Server.listen (net.js:1390:5)",
        "filename": "net.js",
-       "line": 1389,
+       "line": 1390,
        "collum": 5
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:10:8)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:10:8)",
        "filename": "/test/scripts/tcp.js",
        "line": 10,
        "collum": 8
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
      "children": [
       {
        "name": "TCP",
-       "init": 18739151,
-       "destroy": 30704760,
+       "init": 24145581,
+       "destroy": 38805901,
        "before": [
-        24804028
+        31292176
        ],
        "after": [
-        26956833
+        34049925
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "createServerHandle (net.js:1179:14)",
+         "description": "createServerHandle (net.js:1180:14)",
          "filename": "net.js",
-         "line": 1179,
+         "line": 1180,
          "collum": 14
         },
         {
-         "description": "Server._listen2 (net.js:1236:14)",
+         "description": "Server._listen2 (net.js:1237:14)",
          "filename": "net.js",
-         "line": 1236,
+         "line": 1237,
          "collum": 14
         },
         {
-         "description": "listen (net.js:1288:10)",
+         "description": "listen (net.js:1289:10)",
          "filename": "net.js",
-         "line": 1288,
+         "line": 1289,
          "collum": 10
         },
         {
-         "description": "net.js:1398:9",
+         "description": "net.js:1399:9",
          "filename": "net.js",
-         "line": 1398,
+         "line": 1399,
          "collum": 9
         },
         {
-         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:65:16)",
+         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)",
          "filename": "dns.js",
-         "line": 65,
+         "line": 62,
          "collum": 16
         },
         {
-         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:84:10)",
+         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)",
          "filename": "dns.js",
-         "line": 84,
+         "line": 81,
          "collum": 10
         }
        ],
        "children": [
         {
          "name": "TCP",
-         "init": 24785316,
-         "destroy": 31965143,
+         "init": 31267043,
+         "destroy": 40583516,
          "before": [
-          30713839,
-          31958640
+          38822224,
+          40573516
          ],
          "after": [
-          31831628,
-          31962822
+          40418767,
+          40579459
          ],
+         "unrefed": false,
          "stack": [],
          "children": [
           {
            "name": "NextTickWrap",
-           "init": 31006347,
-           "destroy": 31874301,
+           "init": 39238445,
+           "destroy": 40471444,
            "before": [
-            31836694
+            40425061
            ],
            "after": [
-            31871544
+            40468157
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "Server._emitCloseIfDrained (net.js:1542:11)",
+             "description": "Server._emitCloseIfDrained (net.js:1543:11)",
              "filename": "net.js",
-             "line": 1542,
+             "line": 1543,
              "collum": 11
             },
             {
-             "description": "Socket._destroy (net.js:510:20)",
+             "description": "Socket._destroy (net.js:511:20)",
              "filename": "net.js",
-             "line": 510,
+             "line": 511,
              "collum": 20
             },
             {
-             "description": "Socket.destroy (net.js:518:8)",
+             "description": "Socket.destroy (net.js:519:8)",
              "filename": "net.js",
-             "line": 518,
+             "line": 519,
              "collum": 8
             },
             {
-             "description": "maybeDestroy (net.js:442:12)",
+             "description": "maybeDestroy (net.js:443:12)",
              "filename": "net.js",
-             "line": 442,
+             "line": 443,
              "collum": 12
             },
             {
-             "description": "TCP.onread (net.js:570:5)",
+             "description": "TCP.onread (net.js:571:5)",
              "filename": "net.js",
-             "line": 570,
+             "line": 571,
              "collum": 5
             }
            ],
@@ -319,37 +324,38 @@
           },
           {
            "name": "NextTickWrap",
-           "init": 31172620,
-           "destroy": 31952345,
+           "init": 39501578,
+           "destroy": 40564348,
            "before": [
-            31876952
+            40474994
            ],
            "after": [
-            31949836
+            40561409
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "endReadable (_stream_readable.js:966:13)",
+             "description": "endReadable (_stream_readable.js:965:13)",
              "filename": "_stream_readable.js",
-             "line": 966,
+             "line": 965,
              "collum": 13
             },
             {
-             "description": "Socket.Readable.read (_stream_readable.js:300:7)",
+             "description": "Socket.Readable.read (_stream_readable.js:299:7)",
              "filename": "_stream_readable.js",
-             "line": 300,
+             "line": 299,
              "collum": 7
             },
             {
-             "description": "Socket.read (net.js:299:43)",
+             "description": "Socket.read (net.js:300:43)",
              "filename": "net.js",
-             "line": 299,
+             "line": 300,
              "collum": 43
             },
             {
-             "description": "Socket.onSocketEnd (net.js:267:10)",
+             "description": "Socket.onSocketEnd (net.js:268:10)",
              "filename": "net.js",
-             "line": 267,
+             "line": 268,
              "collum": 10
             },
             {
@@ -365,9 +371,9 @@
              "collum": 7
             },
             {
-             "description": "TCP.onread (net.js:579:8)",
+             "description": "TCP.onread (net.js:580:8)",
              "filename": "net.js",
-             "line": 579,
+             "line": 580,
              "collum": 8
             }
            ],
@@ -377,14 +383,15 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 26677552,
-         "destroy": 27325552,
+         "init": 33703593,
+         "destroy": 34558616,
          "before": [
-          26965840
+          34123469
          ],
          "after": [
-          27322657
+          34555567
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "onwrite (_stream_writable.js:350:15)",
@@ -399,15 +406,15 @@
            "collum": 5
           },
           {
-           "description": "Socket._writeGeneric (net.js:714:5)",
+           "description": "Socket._writeGeneric (net.js:715:5)",
            "filename": "net.js",
-           "line": 714,
+           "line": 715,
            "collum": 5
           },
           {
-           "description": "Socket._write (net.js:724:8)",
+           "description": "Socket._write (net.js:725:8)",
            "filename": "net.js",
-           "line": 724,
+           "line": 725,
            "collum": 8
           },
           {
@@ -429,9 +436,9 @@
            "collum": 11
           },
           {
-           "description": "Socket.write (net.js:650:40)",
+           "description": "Socket.write (net.js:651:40)",
            "filename": "net.js",
-           "line": 650,
+           "line": 651,
            "collum": 40
           },
           {
@@ -441,13 +448,13 @@
            "collum": 10
           },
           {
-           "description": "Socket.end (net.js:422:31)",
+           "description": "Socket.end (net.js:423:31)",
            "filename": "net.js",
-           "line": 422,
+           "line": 423,
            "collum": 31
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:7:10)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:7:10)",
            "filename": "/test/scripts/tcp.js",
            "line": 7,
            "collum": 10
@@ -465,28 +472,29 @@
            "collum": 7
           },
           {
-           "description": "TCP.onconnection (net.js:1458:8)",
+           "description": "TCP.onconnection (net.js:1459:8)",
            "filename": "net.js",
-           "line": 1458,
+           "line": 1459,
            "collum": 8
           }
          ],
          "children": [
           {
            "name": "ShutdownWrap",
-           "init": 27274980,
-           "destroy": 27495387,
+           "init": 34478081,
+           "destroy": 34730051,
            "before": [
-            27356390
+            34581419
            ],
            "after": [
-            27491433
+            34725389
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "Socket.onSocketFinish (net.js:225:26)",
+             "description": "Socket.onSocketFinish (net.js:226:26)",
              "filename": "net.js",
-             "line": 225,
+             "line": 226,
              "collum": 26
             },
             {
@@ -534,76 +542,78 @@
       },
       {
        "name": "NextTickWrap",
-       "init": 19843479,
-       "destroy": 22889996,
+       "init": 25512314,
+       "destroy": 29140288,
        "before": [
-        20204739
+        25974807
        ],
        "after": [
-        22812032
+        29021052
        ],
+       "unrefed": false,
        "stack": [
         {
-         "description": "Server._listen2 (net.js:1266:11)",
+         "description": "Server._listen2 (net.js:1267:11)",
          "filename": "net.js",
-         "line": 1266,
+         "line": 1267,
          "collum": 11
         },
         {
-         "description": "listen (net.js:1288:10)",
+         "description": "listen (net.js:1289:10)",
          "filename": "net.js",
-         "line": 1288,
+         "line": 1289,
          "collum": 10
         },
         {
-         "description": "net.js:1398:9",
+         "description": "net.js:1399:9",
          "filename": "net.js",
-         "line": 1398,
+         "line": 1399,
          "collum": 9
         },
         {
-         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:65:16)",
+         "description": "GetAddrInfoReqWrap.asyncCallback [as callback] (dns.js:62:16)",
          "filename": "dns.js",
-         "line": 65,
+         "line": 62,
          "collum": 16
         },
         {
-         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:84:10)",
+         "description": "GetAddrInfoReqWrap.onlookup [as oncomplete] (dns.js:81:10)",
          "filename": "dns.js",
-         "line": 84,
+         "line": 81,
          "collum": 10
         }
        ],
        "children": [
         {
          "name": "TCP",
-         "init": 22073337,
-         "destroy": 30699066,
+         "init": 28160519,
+         "destroy": 38801385,
          "before": [
-          27523497,
-          28547871,
-          30668504
+          34760385,
+          36035523,
+          38745661
          ],
          "after": [
-          28400511,
-          30430718,
-          30695740
+          35858973,
+          38378996,
+          38796469
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "Socket.connect (net.js:913:40)",
+           "description": "Socket.connect (net.js:914:40)",
            "filename": "net.js",
-           "line": 913,
+           "line": 914,
            "collum": 40
           },
           {
-           "description": "Object.exports.connect.exports.createConnection (net.js:70:35)",
+           "description": "Object.exports.connect.exports.createConnection (net.js:69:35)",
            "filename": "net.js",
-           "line": 70,
+           "line": 69,
            "collum": 35
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:12:22)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:12:22)",
            "filename": "/test/scripts/tcp.js",
            "line": 12,
            "collum": 22
@@ -627,9 +637,9 @@
            "collum": 7
           },
           {
-           "description": "emitListeningNT (net.js:1278:10)",
+           "description": "emitListeningNT (net.js:1279:10)",
            "filename": "net.js",
-           "line": 1278,
+           "line": 1279,
            "collum": 10
           },
           {
@@ -648,37 +658,38 @@
          "children": [
           {
            "name": "NextTickWrap",
-           "init": 28324334,
-           "destroy": 28534413,
+           "init": 35759745,
+           "destroy": 36020155,
            "before": [
-            28410301
+            35866219
            ],
            "after": [
-            28518665
+            36014373
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "maybeReadMore (_stream_readable.js:447:13)",
+             "description": "maybeReadMore (_stream_readable.js:446:13)",
              "filename": "_stream_readable.js",
-             "line": 447,
+             "line": 446,
              "collum": 13
             },
             {
-             "description": "readableAddChunk (_stream_readable.js:192:7)",
+             "description": "readableAddChunk (_stream_readable.js:191:7)",
              "filename": "_stream_readable.js",
-             "line": 192,
+             "line": 191,
              "collum": 7
             },
             {
-             "description": "Socket.Readable.push (_stream_readable.js:135:10)",
+             "description": "Socket.Readable.push (_stream_readable.js:134:10)",
              "filename": "_stream_readable.js",
-             "line": 135,
+             "line": 134,
              "collum": 10
             },
             {
-             "description": "TCP.onread (net.js:542:20)",
+             "description": "TCP.onread (net.js:543:20)",
              "filename": "net.js",
-             "line": 542,
+             "line": 543,
              "collum": 20
             }
            ],
@@ -686,31 +697,32 @@
           },
           {
            "name": "NextTickWrap",
-           "init": 29043457,
-           "destroy": 30661386,
+           "init": 36593620,
+           "destroy": 38733803,
            "before": [
-            30436921
+            38389132
            ],
            "after": [
-            30657865
+            38729468
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "endReadable (_stream_readable.js:966:13)",
+             "description": "endReadable (_stream_readable.js:965:13)",
              "filename": "_stream_readable.js",
-             "line": 966,
+             "line": 965,
              "collum": 13
             },
             {
-             "description": "Socket.Readable.read (_stream_readable.js:300:7)",
+             "description": "Socket.Readable.read (_stream_readable.js:299:7)",
              "filename": "_stream_readable.js",
-             "line": 300,
+             "line": 299,
              "collum": 7
             },
             {
-             "description": "Socket.onSocketEnd (net.js:267:10)",
+             "description": "Socket.onSocketEnd (net.js:268:10)",
              "filename": "net.js",
-             "line": 267,
+             "line": 268,
              "collum": 10
             },
             {
@@ -726,9 +738,9 @@
              "collum": 7
             },
             {
-             "description": "TCP.onread (net.js:579:8)",
+             "description": "TCP.onread (net.js:580:8)",
              "filename": "net.js",
-             "line": 579,
+             "line": 580,
              "collum": 8
             }
            ],
@@ -736,10 +748,11 @@
           },
           {
            "name": "Pipe",
-           "init": 29917100,
+           "init": 37670781,
            "destroy": null,
            "before": [],
            "after": [],
+           "unrefed": true,
            "stack": [
             {
              "description": "createHandle (net.js:33:31)",
@@ -748,9 +761,9 @@
              "collum": 31
             },
             {
-             "description": "new Socket (net.js:138:20)",
+             "description": "new Socket (net.js:139:20)",
              "filename": "net.js",
-             "line": 138,
+             "line": 139,
              "collum": 20
             },
             {
@@ -766,21 +779,21 @@
              "collum": 14
             },
             {
-             "description": "Socket._destroy (net.js:484:25)",
+             "description": "Socket._destroy (net.js:485:25)",
              "filename": "net.js",
-             "line": 484,
+             "line": 485,
              "collum": 25
             },
             {
-             "description": "Socket.destroy (net.js:518:8)",
+             "description": "Socket.destroy (net.js:519:8)",
              "filename": "net.js",
-             "line": 518,
+             "line": 519,
              "collum": 8
             },
             {
-             "description": "Socket.onSocketFinish (net.js:213:17)",
+             "description": "Socket.onSocketFinish (net.js:214:17)",
              "filename": "net.js",
-             "line": 213,
+             "line": 214,
              "collum": 17
             },
             {
@@ -814,21 +827,21 @@
              "collum": 5
             },
             {
-             "description": "Socket.end (net.js:422:31)",
+             "description": "Socket.end (net.js:423:31)",
              "filename": "net.js",
-             "line": 422,
+             "line": 423,
              "collum": 31
             },
             {
-             "description": "Socket.destroySoon (net.js:449:10)",
+             "description": "Socket.destroySoon (net.js:450:10)",
              "filename": "net.js",
-             "line": 449,
+             "line": 450,
              "collum": 10
             },
             {
-             "description": "Socket.onSocketEnd (net.js:272:10)",
+             "description": "Socket.onSocketEnd (net.js:273:10)",
              "filename": "net.js",
-             "line": 272,
+             "line": 273,
              "collum": 10
             },
             {
@@ -844,9 +857,9 @@
              "collum": 7
             },
             {
-             "description": "TCP.onread (net.js:579:8)",
+             "description": "TCP.onread (net.js:580:8)",
              "filename": "net.js",
-             "line": 579,
+             "line": 580,
              "collum": 8
             }
            ],
@@ -856,35 +869,36 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 22726947,
-         "destroy": 23398110,
+         "init": 28917850,
+         "destroy": 29689483,
          "before": [
-          23045240
+          29299505
          ],
          "after": [
-          23386402
+          29675670
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "lookupAndConnect (net.js:961:13)",
+           "description": "lookupAndConnect (net.js:962:13)",
            "filename": "net.js",
-           "line": 961,
+           "line": 962,
            "collum": 13
           },
           {
-           "description": "Socket.connect (net.js:929:5)",
+           "description": "Socket.connect (net.js:930:5)",
            "filename": "net.js",
-           "line": 929,
+           "line": 930,
            "collum": 5
           },
           {
-           "description": "Object.exports.connect.exports.createConnection (net.js:70:35)",
+           "description": "Object.exports.connect.exports.createConnection (net.js:69:35)",
            "filename": "net.js",
-           "line": 70,
+           "line": 69,
            "collum": 35
           },
           {
-           "description": "Server.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:12:22)",
+           "description": "Server.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:12:22)",
            "filename": "/test/scripts/tcp.js",
            "line": 12,
            "collum": 22
@@ -908,9 +922,9 @@
            "collum": 7
           },
           {
-           "description": "emitListeningNT (net.js:1278:10)",
+           "description": "emitListeningNT (net.js:1279:10)",
            "filename": "net.js",
-           "line": 1278,
+           "line": 1279,
            "collum": 10
           },
           {
@@ -929,25 +943,26 @@
          "children": [
           {
            "name": "TCPConnectWrap",
-           "init": 23268103,
-           "destroy": 24718380,
+           "init": 29553341,
+           "destroy": 31204087,
            "before": [
-            23453571
+            29791613
            ],
            "after": [
-            24583240
+            31053564
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "connect (net.js:854:26)",
+             "description": "connect (net.js:856:26)",
              "filename": "net.js",
-             "line": 854,
+             "line": 856,
              "collum": 26
             },
             {
-             "description": "net.js:963:9",
+             "description": "net.js:964:9",
              "filename": "net.js",
-             "line": 963,
+             "line": 964,
              "collum": 9
             },
             {
@@ -966,19 +981,20 @@
            "children": [
             {
              "name": "NextTickWrap",
-             "init": 23803811,
-             "destroy": 24713421,
+             "init": 30113615,
+             "destroy": 31198602,
              "before": [
-              24590497
+              31060603
              ],
              "after": [
-              24709979
+              31195451
              ],
+             "unrefed": false,
              "stack": [
               {
-               "description": "Socket.Readable.on (_stream_readable.js:700:17)",
+               "description": "Socket.Readable.on (_stream_readable.js:699:17)",
                "filename": "_stream_readable.js",
-               "line": 700,
+               "line": 699,
                "collum": 17
               },
               {
@@ -988,7 +1004,7 @@
                "collum": 8
               },
               {
-               "description": "Socket.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tcp.js:13:12)",
+               "description": "Socket.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tcp.js:13:12)",
                "filename": "/test/scripts/tcp.js",
                "line": 13,
                "collum": 12
@@ -1012,9 +1028,9 @@
                "collum": 7
               },
               {
-               "description": "TCPConnectWrap.afterConnect [as oncomplete] (net.js:1067:10)",
+               "description": "TCPConnectWrap.afterConnect [as oncomplete] (net.js:1068:10)",
                "filename": "net.js",
-               "line": 1067,
+               "line": 1068,
                "collum": 10
               }
              ],

--- a/test/expected/tty.json
+++ b/test/expected/tty.json
@@ -2,53 +2,54 @@
  "stdout": "'use strict';\nrequire('../../dprof.js');\n\nconst fs = require('fs');\n\nfs.createReadStream(__filename).pipe(process.stdout);\n",
  "stderr": "",
  "dump": {
-  "total": 20065808,
+  "total": 23138680,
   "version": "0.14.0",
   "root": {
    "name": "root",
    "init": 0,
-   "destroy": 14258639,
+   "destroy": 16311855,
    "before": [
     0
    ],
    "after": [
-    14226362
+    16269850
    ],
+   "unrefed": false,
    "stack": [
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.require (module.js:468:17)",
+     "description": "Module.require (module.js:483:17)",
      "filename": "module.js",
-     "line": 468,
+     "line": 483,
      "collum": 17
     },
     {
@@ -58,77 +59,78 @@
      "collum": 19
     },
     {
-     "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tty.js:2:1)",
+     "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tty.js:2:1)",
      "filename": "/test/scripts/tty.js",
      "line": 2,
      "collum": 1
     },
     {
-     "description": "Module._compile (module.js:541:32)",
+     "description": "Module._compile (module.js:556:32)",
      "filename": "module.js",
-     "line": 541,
+     "line": 556,
      "collum": 32
     },
     {
-     "description": "Object.Module._extensions..js (module.js:550:10)",
+     "description": "Object.Module._extensions..js (module.js:565:10)",
      "filename": "module.js",
-     "line": 550,
+     "line": 565,
      "collum": 10
     },
     {
-     "description": "Module.load (module.js:458:32)",
+     "description": "Module.load (module.js:473:32)",
      "filename": "module.js",
-     "line": 458,
+     "line": 473,
      "collum": 32
     },
     {
-     "description": "tryModuleLoad (module.js:417:12)",
+     "description": "tryModuleLoad (module.js:432:12)",
      "filename": "module.js",
-     "line": 417,
+     "line": 432,
      "collum": 12
     },
     {
-     "description": "Function.Module._load (module.js:409:3)",
+     "description": "Function.Module._load (module.js:424:3)",
      "filename": "module.js",
-     "line": 409,
+     "line": 424,
      "collum": 3
     },
     {
-     "description": "Module.runMain (module.js:575:10)",
+     "description": "Module.runMain (module.js:590:10)",
      "filename": "module.js",
-     "line": 575,
+     "line": 590,
      "collum": 10
     },
     {
-     "description": "run (bootstrap_node.js:352:7)",
+     "description": "run (bootstrap_node.js:394:7)",
      "filename": "bootstrap_node.js",
-     "line": 352,
+     "line": 394,
      "collum": 7
     },
     {
-     "description": "startup (bootstrap_node.js:144:9)",
+     "description": "startup (bootstrap_node.js:149:9)",
      "filename": "bootstrap_node.js",
-     "line": 144,
+     "line": 149,
      "collum": 9
     },
     {
-     "description": "bootstrap_node.js:467:3",
+     "description": "bootstrap_node.js:509:3",
      "filename": "bootstrap_node.js",
-     "line": 467,
+     "line": 509,
      "collum": 3
     }
    ],
    "children": [
     {
      "name": "FSReqWrap",
-     "init": 3316682,
-     "destroy": 16787239,
+     "init": 4095922,
+     "destroy": 19001230,
      "before": [
-      15535016
+      17830268
      ],
      "after": [
-      16771731
+      18969394
      ],
+     "unrefed": false,
      "stack": [
       {
        "description": "Object.fs.open (fs.js:631:11)",
@@ -137,95 +139,96 @@
        "collum": 11
       },
       {
-       "description": "ReadStream.open (fs.js:1714:6)",
+       "description": "ReadStream.open (fs.js:1916:6)",
        "filename": "fs.js",
-       "line": 1714,
+       "line": 1916,
        "collum": 6
       },
       {
-       "description": "new ReadStream (fs.js:1701:10)",
+       "description": "new ReadStream (fs.js:1903:10)",
        "filename": "fs.js",
-       "line": 1701,
+       "line": 1903,
        "collum": 10
       },
       {
-       "description": "Object.fs.createReadStream (fs.js:1649:10)",
+       "description": "Object.fs.createReadStream (fs.js:1850:10)",
        "filename": "fs.js",
-       "line": 1649,
+       "line": 1850,
        "collum": 10
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tty.js:6:4)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tty.js:6:4)",
        "filename": "/test/scripts/tty.js",
        "line": 6,
        "collum": 4
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
      "children": [
       {
        "name": "FSReqWrap",
-       "init": 16100291,
-       "destroy": 18979753,
+       "init": 18451942,
+       "destroy": 21736487,
        "before": [
-        16808643
+        19026335
        ],
        "after": [
-        18788531
+        21480093
        ],
+       "unrefed": false,
        "stack": [
         {
          "description": "Object.fs.read (fs.js:687:11)",
@@ -234,15 +237,15 @@
          "collum": 11
         },
         {
-         "description": "ReadStream._read (fs.js:1762:6)",
+         "description": "ReadStream._read (fs.js:1964:6)",
          "filename": "fs.js",
-         "line": 1762,
+         "line": 1964,
          "collum": 6
         },
         {
-         "description": "ReadStream.<anonymous> (fs.js:1733:12)",
+         "description": "ReadStream.<anonymous> (fs.js:1935:12)",
          "filename": "fs.js",
-         "line": 1733,
+         "line": 1935,
          "collum": 12
         },
         {
@@ -264,9 +267,9 @@
          "collum": 7
         },
         {
-         "description": "fs.js:1724:10",
+         "description": "fs.js:1926:10",
          "filename": "fs.js",
-         "line": 1724,
+         "line": 1926,
          "collum": 10
         },
         {
@@ -279,14 +282,15 @@
        "children": [
         {
          "name": "NextTickWrap",
-         "init": 18040975,
-         "destroy": 18914878,
+         "init": 20542811,
+         "destroy": 21653002,
          "before": [
-          18799651
+          21497725
          ],
          "after": [
-          18910284
+          21647711
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "onwrite (_stream_writable.js:350:15)",
@@ -301,15 +305,15 @@
            "collum": 5
           },
           {
-           "description": "Socket._writeGeneric (net.js:714:5)",
+           "description": "Socket._writeGeneric (net.js:715:5)",
            "filename": "net.js",
-           "line": 714,
+           "line": 715,
            "collum": 5
           },
           {
-           "description": "Socket._write (net.js:724:8)",
+           "description": "Socket._write (net.js:725:8)",
            "filename": "net.js",
-           "line": 724,
+           "line": 725,
            "collum": 8
           },
           {
@@ -331,15 +335,15 @@
            "collum": 11
           },
           {
-           "description": "Socket.write (net.js:650:40)",
+           "description": "Socket.write (net.js:651:40)",
            "filename": "net.js",
-           "line": 650,
+           "line": 651,
            "collum": 40
           },
           {
-           "description": "ReadStream.ondata (_stream_readable.js:556:20)",
+           "description": "ReadStream.ondata (_stream_readable.js:555:20)",
            "filename": "_stream_readable.js",
-           "line": 556,
+           "line": 555,
            "collum": 20
           },
           {
@@ -355,21 +359,21 @@
            "collum": 7
           },
           {
-           "description": "readableAddChunk (_stream_readable.js:177:18)",
+           "description": "readableAddChunk (_stream_readable.js:176:18)",
            "filename": "_stream_readable.js",
-           "line": 177,
+           "line": 176,
            "collum": 18
           },
           {
-           "description": "ReadStream.Readable.push (_stream_readable.js:135:10)",
+           "description": "ReadStream.Readable.push (_stream_readable.js:134:10)",
            "filename": "_stream_readable.js",
-           "line": 135,
+           "line": 134,
            "collum": 10
           },
           {
-           "description": "onread (fs.js:1780:12)",
+           "description": "onread (fs.js:1984:12)",
            "filename": "fs.js",
-           "line": 1780,
+           "line": 1984,
            "collum": 12
           },
           {
@@ -383,14 +387,15 @@
         },
         {
          "name": "FSReqWrap",
-         "init": 18526317,
-         "destroy": 19930630,
+         "init": 21150636,
+         "destroy": 22975431,
          "before": [
-          18989607
+          21748637
          ],
          "after": [
-          19278966
+          22146735
          ],
+         "unrefed": false,
          "stack": [
           {
            "description": "Object.fs.read (fs.js:687:11)",
@@ -399,33 +404,33 @@
            "collum": 11
           },
           {
-           "description": "ReadStream._read (fs.js:1762:6)",
+           "description": "ReadStream._read (fs.js:1964:6)",
            "filename": "fs.js",
-           "line": 1762,
+           "line": 1964,
            "collum": 6
           },
           {
-           "description": "ReadStream.Readable.read (_stream_readable.js:349:10)",
+           "description": "ReadStream.Readable.read (_stream_readable.js:348:10)",
            "filename": "_stream_readable.js",
-           "line": 349,
+           "line": 348,
            "collum": 10
           },
           {
-           "description": "readableAddChunk (_stream_readable.js:178:18)",
+           "description": "readableAddChunk (_stream_readable.js:177:18)",
            "filename": "_stream_readable.js",
-           "line": 178,
+           "line": 177,
            "collum": 18
           },
           {
-           "description": "ReadStream.Readable.push (_stream_readable.js:135:10)",
+           "description": "ReadStream.Readable.push (_stream_readable.js:134:10)",
            "filename": "_stream_readable.js",
-           "line": 135,
+           "line": 134,
            "collum": 10
           },
           {
-           "description": "onread (fs.js:1780:12)",
+           "description": "onread (fs.js:1984:12)",
            "filename": "fs.js",
-           "line": 1780,
+           "line": 1984,
            "collum": 12
           },
           {
@@ -438,67 +443,68 @@
          "children": [
           {
            "name": "NextTickWrap",
-           "init": 19219619,
-           "destroy": 19925509,
+           "init": 22053649,
+           "destroy": 22968674,
            "before": [
-            19284734
+            22151147
            ],
            "after": [
-            19921988
+            22961250
            ],
+           "unrefed": false,
            "stack": [
             {
-             "description": "endReadable (_stream_readable.js:966:13)",
+             "description": "endReadable (_stream_readable.js:965:13)",
              "filename": "_stream_readable.js",
-             "line": 966,
+             "line": 965,
              "collum": 13
             },
             {
-             "description": "ReadStream.Readable.read (_stream_readable.js:300:7)",
+             "description": "ReadStream.Readable.read (_stream_readable.js:299:7)",
              "filename": "_stream_readable.js",
-             "line": 300,
+             "line": 299,
              "collum": 7
             },
             {
-             "description": "flow (_stream_readable.js:762:34)",
+             "description": "flow (_stream_readable.js:761:34)",
              "filename": "_stream_readable.js",
-             "line": 762,
+             "line": 761,
              "collum": 34
             },
             {
-             "description": "emitReadable_ (_stream_readable.js:434:3)",
+             "description": "emitReadable_ (_stream_readable.js:433:3)",
              "filename": "_stream_readable.js",
-             "line": 434,
+             "line": 433,
              "collum": 3
             },
             {
-             "description": "emitReadable (_stream_readable.js:427:7)",
+             "description": "emitReadable (_stream_readable.js:426:7)",
              "filename": "_stream_readable.js",
-             "line": 427,
+             "line": 426,
              "collum": 7
             },
             {
-             "description": "onEofChunk (_stream_readable.js:412:3)",
+             "description": "onEofChunk (_stream_readable.js:411:3)",
              "filename": "_stream_readable.js",
-             "line": 412,
+             "line": 411,
              "collum": 3
             },
             {
-             "description": "readableAddChunk (_stream_readable.js:154:5)",
+             "description": "readableAddChunk (_stream_readable.js:153:5)",
              "filename": "_stream_readable.js",
-             "line": 154,
+             "line": 153,
              "collum": 5
             },
             {
-             "description": "ReadStream.Readable.push (_stream_readable.js:135:10)",
+             "description": "ReadStream.Readable.push (_stream_readable.js:134:10)",
              "filename": "_stream_readable.js",
-             "line": 135,
+             "line": 134,
              "collum": 10
             },
             {
-             "description": "onread (fs.js:1780:12)",
+             "description": "onread (fs.js:1984:12)",
              "filename": "fs.js",
-             "line": 1780,
+             "line": 1984,
              "collum": 12
             },
             {
@@ -511,14 +517,15 @@
            "children": [
             {
              "name": "FSReqWrap",
-             "init": 19616407,
-             "destroy": 19983022,
+             "init": 22601585,
+             "destroy": 23043253,
              "before": [
-              19939471
+              22986964
              ],
              "after": [
-              19979927
+              23038914
              ],
+             "unrefed": false,
              "stack": [
               {
                "description": "Object.fs.close (fs.js:605:11)",
@@ -527,27 +534,27 @@
                "collum": 11
               },
               {
-               "description": "close (fs.js:1809:8)",
+               "description": "close (fs.js:2013:8)",
                "filename": "fs.js",
-               "line": 1809,
+               "line": 2013,
                "collum": 8
               },
               {
-               "description": "ReadStream.close (fs.js:1806:3)",
+               "description": "ReadStream.close (fs.js:2010:3)",
                "filename": "fs.js",
-               "line": 1806,
+               "line": 2010,
                "collum": 3
               },
               {
-               "description": "ReadStream.destroy (fs.js:1790:8)",
+               "description": "ReadStream.destroy (fs.js:1994:8)",
                "filename": "fs.js",
-               "line": 1790,
+               "line": 1994,
                "collum": 8
               },
               {
-               "description": "ReadStream.<anonymous> (fs.js:1705:12)",
+               "description": "ReadStream.<anonymous> (fs.js:1907:12)",
                "filename": "fs.js",
-               "line": 1705,
+               "line": 1907,
                "collum": 12
               },
               {
@@ -563,9 +570,9 @@
                "collum": 7
               },
               {
-               "description": "endReadableNT (_stream_readable.js:975:12)",
+               "description": "endReadableNT (_stream_readable.js:974:12)",
                "filename": "_stream_readable.js",
-               "line": 975,
+               "line": 974,
                "collum": 12
               },
               {
@@ -589,37 +596,38 @@
         },
         {
          "name": "NextTickWrap",
-         "init": 18707846,
-         "destroy": 18972566,
+         "init": 21372353,
+         "destroy": 21727298,
          "before": [
-          18918485
+          21657679
          ],
          "after": [
-          18970078
+          21724128
          ],
+         "unrefed": false,
          "stack": [
           {
-           "description": "maybeReadMore (_stream_readable.js:447:13)",
+           "description": "maybeReadMore (_stream_readable.js:446:13)",
            "filename": "_stream_readable.js",
-           "line": 447,
+           "line": 446,
            "collum": 13
           },
           {
-           "description": "readableAddChunk (_stream_readable.js:192:7)",
+           "description": "readableAddChunk (_stream_readable.js:191:7)",
            "filename": "_stream_readable.js",
-           "line": 192,
+           "line": 191,
            "collum": 7
           },
           {
-           "description": "ReadStream.Readable.push (_stream_readable.js:135:10)",
+           "description": "ReadStream.Readable.push (_stream_readable.js:134:10)",
            "filename": "_stream_readable.js",
-           "line": 135,
+           "line": 134,
            "collum": 10
           },
           {
-           "description": "onread (fs.js:1780:12)",
+           "description": "onread (fs.js:1984:12)",
            "filename": "fs.js",
-           "line": 1780,
+           "line": 1984,
            "collum": 12
           },
           {
@@ -637,10 +645,11 @@
     },
     {
      "name": "Pipe",
-     "init": 12387964,
+     "init": 13976094,
      "destroy": null,
      "before": [],
      "after": [],
+     "unrefed": true,
      "stack": [
       {
        "description": "createHandle (net.js:33:31)",
@@ -649,9 +658,9 @@
        "collum": 31
       },
       {
-       "description": "new Socket (net.js:138:20)",
+       "description": "new Socket (net.js:139:20)",
        "filename": "net.js",
-       "line": 138,
+       "line": 139,
        "collum": 20
       },
       {
@@ -667,63 +676,63 @@
        "collum": 14
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tty.js:6:45)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tty.js:6:45)",
        "filename": "/test/scripts/tty.js",
        "line": 6,
        "collum": 45
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],
@@ -731,97 +740,98 @@
     },
     {
      "name": "NextTickWrap",
-     "init": 13541317,
-     "destroy": 15230135,
+     "init": 15620591,
+     "destroy": 17528494,
      "before": [
-      14513957
+      16636115
      ],
      "after": [
-      15159279
+      17417121
      ],
+     "unrefed": false,
      "stack": [
       {
-       "description": "resume (_stream_readable.js:731:13)",
+       "description": "resume (_stream_readable.js:730:13)",
        "filename": "_stream_readable.js",
-       "line": 731,
+       "line": 730,
        "collum": 13
       },
       {
-       "description": "ReadStream.Readable.resume (_stream_readable.js:723:5)",
+       "description": "ReadStream.Readable.resume (_stream_readable.js:722:5)",
        "filename": "_stream_readable.js",
-       "line": 723,
+       "line": 722,
        "collum": 5
       },
       {
-       "description": "ReadStream.Readable.on (_stream_readable.js:693:12)",
+       "description": "ReadStream.Readable.on (_stream_readable.js:692:12)",
        "filename": "_stream_readable.js",
-       "line": 693,
+       "line": 692,
        "collum": 12
       },
       {
-       "description": "ReadStream.Readable.pipe (_stream_readable.js:552:7)",
+       "description": "ReadStream.Readable.pipe (_stream_readable.js:551:7)",
        "filename": "_stream_readable.js",
-       "line": 552,
+       "line": 551,
        "collum": 7
       },
       {
-       "description": "Object.<anonymous> (/Users/Andreas/Sites/node_modules/dprof/test/scripts/tty.js:6:33)",
+       "description": "Object.<anonymous> (/Users/Jeremiah/Documents/dprof/test/scripts/tty.js:6:33)",
        "filename": "/test/scripts/tty.js",
        "line": 6,
        "collum": 33
       },
       {
-       "description": "Module._compile (module.js:541:32)",
+       "description": "Module._compile (module.js:556:32)",
        "filename": "module.js",
-       "line": 541,
+       "line": 556,
        "collum": 32
       },
       {
-       "description": "Object.Module._extensions..js (module.js:550:10)",
+       "description": "Object.Module._extensions..js (module.js:565:10)",
        "filename": "module.js",
-       "line": 550,
+       "line": 565,
        "collum": 10
       },
       {
-       "description": "Module.load (module.js:458:32)",
+       "description": "Module.load (module.js:473:32)",
        "filename": "module.js",
-       "line": 458,
+       "line": 473,
        "collum": 32
       },
       {
-       "description": "tryModuleLoad (module.js:417:12)",
+       "description": "tryModuleLoad (module.js:432:12)",
        "filename": "module.js",
-       "line": 417,
+       "line": 432,
        "collum": 12
       },
       {
-       "description": "Function.Module._load (module.js:409:3)",
+       "description": "Function.Module._load (module.js:424:3)",
        "filename": "module.js",
-       "line": 409,
+       "line": 424,
        "collum": 3
       },
       {
-       "description": "Module.runMain (module.js:575:10)",
+       "description": "Module.runMain (module.js:590:10)",
        "filename": "module.js",
-       "line": 575,
+       "line": 590,
        "collum": 10
       },
       {
-       "description": "run (bootstrap_node.js:352:7)",
+       "description": "run (bootstrap_node.js:394:7)",
        "filename": "bootstrap_node.js",
-       "line": 352,
+       "line": 394,
        "collum": 7
       },
       {
-       "description": "startup (bootstrap_node.js:144:9)",
+       "description": "startup (bootstrap_node.js:149:9)",
        "filename": "bootstrap_node.js",
-       "line": 144,
+       "line": 149,
        "collum": 9
       },
       {
-       "description": "bootstrap_node.js:467:3",
+       "description": "bootstrap_node.js:509:3",
        "filename": "bootstrap_node.js",
-       "line": 467,
+       "line": 509,
        "collum": 3
       }
      ],

--- a/test/util.js
+++ b/test/util.js
@@ -28,6 +28,7 @@ function simplifyDump(dump) {
       destroy: node.destroy === null ? 'null' : typeof node.destroy,
       before: `Array(${node.before.length})`,
       after: `Array(${node.after.length})`,
+      unrefed: `${node.unrefed}`,
       stack: node.stack.map((cite) => cite.filename),
       children: node.children.map(recursive)
     };

--- a/visualizer/flatten.js
+++ b/visualizer/flatten.js
@@ -27,6 +27,7 @@ function Node(parent, node, index) {
   // Info
   this.name = node.name;
   this.stack = node.stack;
+  this.unrefed = node.unrefed;
 
   // Convert init time
   this.init = node.init * ns2s;

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -107,6 +107,11 @@
     stroke: #D0D0D0;
   }
 
+  .timeline.unrefed .wait,
+  .timeline.unrefed .callback {
+    opacity: 0.5;
+  }
+
   .timeline .init {
     stroke-width: 2px;
     stroke: rgba(0, 0, 0, 0.7);

--- a/visualizer/info.js
+++ b/visualizer/info.js
@@ -41,6 +41,7 @@ StatsLayout.prototype.draw = function () {
 
     stats += '\n' +
       `handle: ${this._node.name}\n` +
+      `weak (unrefed): ${this._node.unrefed}\n` +
       `start: ${this._node.init.toFixed(8)} sec\n` +
       `wait: ${toms(wait, 11)} ms\n` +
       `callback: ${toms(callback, 7)} ms`;

--- a/visualizer/timeline.js
+++ b/visualizer/timeline.js
@@ -190,7 +190,10 @@ TimelineLayout.prototype._drawTimelines = function () {
   // Insert groups
   const barEnter = bar
     .enter().append('g')
-      .attr('class', 'timeline');
+      .attr('class', 'timeline')
+      // Change bar opacity if unrefed
+      .classed('unrefed', (d) => d.unrefed);
+
 
   // Draw background line
   barEnter.append('path')


### PR DESCRIPTION
Not without problems, but a good start.

See https://github.com/AndreasMadsen/dprof/issues/7

Looks like this:

<img width="417" alt="screen shot 2016-08-29 at 6 59 47 pm" src="https://cloud.githubusercontent.com/assets/1093990/18070289/d9ac749e-6e1a-11e6-86b8-bc29d3f7a110.png">

---

Note: the `nextTick` check isn't ideal but functions.

Better would be to track where a handle gets unrefed/re-refed/etc on the timeline via wrapping.

---

Note: After some investigation, I discovered that `TTY`(Wrap) and `Pipe`(Wrap) are always unrefed by some unknown mechanism. Even though `Pipe` actually has a `.ref()`, the following code shows that it does nothing whatsoever:

```
echo "console.log('hi'); process.stdout._handle.ref()" | node | grep ''
```