### PR TITLE
[feature] improved visualization of un/ref

### DIFF
--- a/dprof.js
+++ b/dprof.js
@@ -60,7 +60,9 @@ function Node(uid, handle, name, stack, parent) {
   this._destroy = Infinity;
   this._before = [];
   this._after = [];
-  this.unrefed = this.name === 'TTY' || this.name === 'Pipe' || handle._timerUnref === true;
+  this._unref = [];
+  this._ref = [];
+  this.unrefed = this.name === 'TTYWRAP' || this.name === 'PIPEWRAP' || handle._timerUnref === true;
   this.children = [];
   this.stack = stack.map(function (site) {
     return new Site(site);
@@ -70,7 +72,7 @@ function Node(uid, handle, name, stack, parent) {
     const unref = handle.unref;
     handle.unref = () => {
       const ret = unref.call(handle);
-      this.unrefed = true;
+      this._unref.push(timestamp())
       return ret;
     }
   }
@@ -78,7 +80,7 @@ function Node(uid, handle, name, stack, parent) {
     const ref = handle.ref;
     handle.ref = () => {
       const ret = ref.call(handle);
-      this.unrefed = false;
+      this._ref.push(timestamp())
       return ret;
     }
   }
@@ -133,6 +135,8 @@ Node.prototype.toJSON = function () {
     destroy: this._destroy,
     before: this._before,
     after: this._after,
+    unref: this._unref,
+    ref: this._ref,
     unrefed: this.unrefed,
     stack: this.stack,
     children: this.children

--- a/visualizer/flatten.js
+++ b/visualizer/flatten.js
@@ -85,7 +85,7 @@ function Node(node) {
   this.name = node.name;
   this.uid = node.uid;
   this.stack = node.stack;
-  this.unrefed = node.unrefed;
+  this._unrefed = node.unrefed;
 
   // Convert init time
   this.init = node.init * ns2s;
@@ -96,6 +96,27 @@ function Node(node) {
   // Convert before and after time
   this.before = node.before.map((v) => v * ns2s);
   this.after = node.after.map((v) => v * ns2s);
+  this.unref = node.unref.map((v) => v * ns2s);
+  this.ref = node.ref.map((v) => v * ns2s);
+
+  // Compile a list of state changes
+  this.stateChanges = []
+  for (const v of this.before) {
+    this.stateChanges.push([v, 'before'])
+  }
+  for (const v of this.after) {
+    this.stateChanges.push([v, 'after'])
+  }
+  for (const v of this.unref) {
+    this.stateChanges.push([v, 'unref'])
+  }
+  for (const v of this.ref) {
+    this.stateChanges.push([v, 'ref'])
+  }
+
+  // Sort the state in order of time
+  this.stateChanges.sort((a, b) => a[0] - b[0])
+
   // Total time, including all children will be updated.
   this.total = 0;
 

--- a/visualizer/index.html
+++ b/visualizer/index.html
@@ -107,18 +107,17 @@
     stroke: #D0D0D0;
   }
 
-  .timeline.unrefed .wait,
-  .timeline.unrefed .callback {
-    opacity: 0.5;
-  }
-
   .timeline .init {
     stroke-width: 2px;
     stroke: rgba(0, 0, 0, 0.7);
   }
-  .timeline .wait {
+  .timeline .wait,
+  .timeline .wait-unref {
     stroke-width: 6px;
     stroke: SteelBlue;
+  }
+  .timeline .wait-unref {
+    opacity: 0.5;
   }
   .timeline .callback {
     stroke-width: 12px;

--- a/visualizer/info.js
+++ b/visualizer/info.js
@@ -42,7 +42,6 @@ StatsLayout.prototype.draw = function () {
     stats += '\n' +
       `handle: ${this._node.name}\n` +
       `uid: ${this._node.uid}\n` +
-      `weak (unrefed): ${this._node.unrefed}\n` +
       `start: ${this._node.init.toFixed(8)} sec\n` +
       `wait: ${toms(wait, 11)} ms\n` +
       `callback: ${toms(callback, 7)} ms`;


### PR DESCRIPTION
Tried to backport, but the un/ref() wrapping just doesn't work well enough in the old shim for many handles.
### Example:

<img width="592" alt="screen shot 2016-10-19 at 11 13 40 am" src="https://cloud.githubusercontent.com/assets/1093990/19514921/4487b6bc-95ed-11e6-9319-cc26401237e0.png">

``` js
const t = setTimeout(()=>{}, 100)

setImmediate(()=>{
  t.unref()
  setTimeout(()=> {
    t.ref()
    process.nextTick(() => setImmediate(()=> {
      t.unref()
      setTimeout(()=> {
        t.ref()
      }, 35)
    }))
  }, 10)
})
```
