### PR TITLE
[fix] use dprof.js.org as host domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ gists.
 
 ```shell
 gzcat dprof.json.gz | dprof upload
-view at: https://andreasmadsen.github.io/dprof/gists/#5e423de3fd6d787d4bcab35fa9cebc7a
+https://dprof.js.org/gists/#6ad16f91d3e599649912315e48ebd1cb
 ```
 
 ## SIGINT (Ctrl-C) Behavior

--- a/bin/upload.js
+++ b/bin/upload.js
@@ -11,7 +11,7 @@ getGzipFile(function (err, dump) {
   uploadGits(dump, function (err, id) {
     if (err) throw err;
 
-    console.log('view at: https://andreasmadsen.github.io/dprof/gists/#' + id);
+    console.log('view at: https://dprof.js.org/gists/#' + id);
   });
 });
 


### PR DESCRIPTION
Fix links once https://github.com/js-org/dns.js.org/pull/939 is merged.

_note: remember to fix the repo website link too._